### PR TITLE
chore: Update Cargo.toml use repository instead of homepage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "python_marshal"
 license = "GPL-3.0-or-later"
 description = "A Rust library for reading and writing Python marshal files."
-homepage = "https://github.com/Svenskithesource/python-marshal"
+repository = "https://github.com/Svenskithesource/python-marshal"
 readme = "README.md"
 version = "0.3.10"
 edition = "2021"


### PR DESCRIPTION
According to the [manifest](https://doc.rust-lang.org/cargo/reference/manifest.html) it seems the `repository` field is preferable.  More explanation https://github.com/szabgab/rust-digger/issues/91